### PR TITLE
updated package options to work with updated package

### DIFF
--- a/beamerthemeCockrell.sty
+++ b/beamerthemeCockrell.sty
@@ -100,7 +100,7 @@
 
 
 %Use correct fonts
-\usepackage[default,osfigures,scale=0.95]{opensans}
+\usepackage[default,oldstyle,scale=0.95]{opensans}
 \usepackage[T1]{fontenc}
 
 


### PR DESCRIPTION
The opensans package has been updated and its options have changed. I have changed the options in the usepackage command to preserve compatibility.

See also: https://tex.stackexchange.com/questions/506603/cant-get-osfigures-working-with-opensans-font